### PR TITLE
rhel8-ubi-init-smallest: Add hostname command

### DIFF
--- a/rhel8-ubi-init-smallest.Containerfile
+++ b/rhel8-ubi-init-smallest.Containerfile
@@ -3,6 +3,7 @@ FROM registry.access.redhat.com/ubi8/ubi-init
 MAINTAINER Jan Hutar <jhutar@redhat.com>
 
 RUN INSTALL_PKGS="\
+  hostname \
   less \
   openssh-server \
   subscription-manager \


### PR DESCRIPTION
This will allow insights-client to run properly.