### PR TITLE
feat: Add RHEL 8 container with Satellite client packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Flavors
 | `rhel8-ubi-init-big_outdated.Containerfile` | RHEL8 | rhel8-ubi-init-smallest | Added extra repository with fake packages and install quite some outdated packages from it so total number of packages is 1000 and it have around 815 applicable updates |
 | `rhel8-ubi-init-utils.Containerfile` | RHEL8 | rhel8-ubi-init-smallest | Small image which, besides other, contain various helper tools handy when debugging the setup we are using |
 | `rhel8-ubi-init-big_outdated-katello_agent611.Containerfile` | RHEL8 | rhel8-ubi-init-big_outdated | This adds katello related client packages (as of now, it's `katello-agent` and its dependencies) to the mix |
+| `rhel8-ubi-init-big_outdated-satellite_client.Containerfile` | RHEL8 | rhel8-ubi-init-big_outdated | Added Satellite client packages (as of now, it's `foreman_ygg_worker`, `katello-agent` and their dependencies) to the mix |
 | `rhel7-ubi-init-smallest.Containerfile` | RHEL7 | ubi7/ubi-init | Just basic set of packages to run `sshd` and `subscription-manager` |
 | `rhel7-ubi-init-big_updated.Containerfile` | RHEL7 | rhel7-ubi-init-smallest | Added extra repository with fake packages and used it to install packages so total number of packages installed is 1000 |
 | `rhel7-ubi-init-big_outdated.Containerfile` | RHEL7 | rhel7-ubi-init-smallest | Added extra repository with fake packages and install quite some outdated packages from it so total number of packages is 1000 and it have around 815 applicable updates |

--- a/build.sh
+++ b/build.sh
@@ -11,6 +11,7 @@ podman build -f rhel8-ubi-init-big_updated.Containerfile -t rhel8-ubi-init-big_u
 podman build -f rhel8-ubi-init-big_outdated.Containerfile -t rhel8-ubi-init-big_outdated .
 podman build -f rhel8-ubi-init-utils.Containerfile -t rhel8-ubi-init-utils .
 podman build -f rhel8-ubi-init-big_outdated-katello_agent611.Containerfile -t rhel8-ubi-init-big_outdated-katello_agent611 .
+podman build -f rhel8-ubi-init-big_outdated-satellite_client.Containerfile -t rhel8-ubi-init-big_outdated-satellite_client .
 podman build -f rhel7-ubi-init-smallest.Containerfile -t rhel7-ubi-init-smallest --build-arg=ROOT_PASSWORD="$ROOT_PASSWORD" --build-arg=ROOT_PUBLIC_KEY="$ROOT_PUBLIC_KEY" .
 podman build -f rhel7-ubi-init-big_updated.Containerfile -t rhel7-ubi-init-big_updated .
 podman build -f rhel7-ubi-init-big_outdated.Containerfile -t rhel7-ubi-init-big_outdated .

--- a/rhel8-ubi-init-big_outdated-satellite_client.Containerfile
+++ b/rhel8-ubi-init-big_outdated-satellite_client.Containerfile
@@ -1,0 +1,13 @@
+FROM rhel8-ubi-init-big_outdated
+
+MAINTAINER Pablo Mendez Hernandez <pmendezh@redhat.com>
+
+RUN echo -e "[satellite_client]\nname=satellite_client\nbaseurl=http://satellite.sat.engineering.redhat.com/pulp/content/Satellite_Engineering/QA/Satellite_Client/custom/Satellite_Client_Composes/Satellite_Client_RHEL8_x86_64/\ngpgcheck=0\nenabled=1" >/etc/yum.repos.d/satellite_client.repo \
+    && dnf install -y foreman_ygg_worker katello-agent \
+    && dnf clean all
+
+WORKDIR /root
+
+EXPOSE 22
+
+CMD ["/sbin/init"]


### PR DESCRIPTION
Based on `rhel8-ubi-init-big_outdated` and with `foreman_ygg_worker`, `katello-agent` and their dependencies.